### PR TITLE
Added E-Hentai Watched list

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/EHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/EHentai.kt
@@ -578,10 +578,17 @@ class EHentai(override val id: Long,
 
     //Filters
     override fun getFilterList() = FilterList(
+            Watched(),
             GenreGroup(),
             AdvancedGroup(),
             ReverseFilter()
     )
+
+    class Watched : Filter.CheckBox("Watched List"), UriFilter {
+        override fun addToUri(builder: Uri.Builder) {
+            builder.appendPath("watched")
+        }
+    }
 
     class GenreOption(name: String, val genreId: Int): Filter.CheckBox(name, false)
     class GenreGroup : Filter.Group<GenreOption>("Genres", listOf(


### PR DESCRIPTION
Allows you to use the e-Hentai watched page to view a listing of your watched tags
- Watched tags still have to be edited in webview or on a browser
- To have a total power limit different from 0, you have to change the power setting with webview in the TachiyomiEH settings profile
- Also works with ExHentai