### PR TITLE
Notification Conflict fix

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -49,7 +49,7 @@ object Notifications {
      * Notification channel and ids used by the library updater.
      */
     const val CHANNEL_UPDATES_TO_EXTS = "updates_ext_channel"
-    const val ID_UPDATES_TO_EXTS = -401
+    const val ID_UPDATES_TO_EXTS = -501
 
     /**
      * Creates the notification channels introduced in Android Oreo.


### PR DESCRIPTION
Something I found while reviewing my pull request, this and the background backup/restore had conflicting notification ids