### PR TITLE
fix system gestures triggering seekbar

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -8,7 +8,6 @@ import com.github.salomonbrys.kotson.nullLong
 import com.github.salomonbrys.kotson.nullObj
 import com.github.salomonbrys.kotson.nullString
 import com.google.gson.JsonParser
-import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
@@ -40,7 +39,7 @@ class NHentai(context: Context) : HttpSource(), LewdSource<NHentaiSearchMetadata
     override val metaClass = NHentaiSearchMetadata::class
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder().build()
-    
+
     override fun fetchPopularManga(page: Int): Observable<MangasPage> {
         // TODO There is currently no way to get the most popular mangas
         // TODO Instead, we delegate this to the latest updates thing to avoid confusing users with an empty screen

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -198,10 +198,10 @@ class ReaderActivity : BaseRxActivity<ReaderActivityBinding, ReaderPresenter>() 
     private fun setEhUtilsVisibility(visible: Boolean) {
         if (visible) {
             binding.ehUtils.visible()
-            binding.expandEhButton.setImageResource(R.drawable.ic_keyboard_arrow_up_white_32dp)
+            binding.expandEhButton.setImageResource(R.drawable.ic_keyboard_arrow_down_white_32dp)
         } else {
             binding.ehUtils.gone()
-            binding.expandEhButton.setImageResource(R.drawable.ic_keyboard_arrow_down_white_32dp)
+            binding.expandEhButton.setImageResource(R.drawable.ic_keyboard_arrow_up_white_32dp)
         }
     }
     // <-- EH
@@ -622,7 +622,7 @@ class ReaderActivity : BaseRxActivity<ReaderActivityBinding, ReaderPresenter>() 
      * Reset menu padding and system bar
      */
     private fun resetDefaultMenuAndBar() {
-        binding.readerMenu.setPadding(0, 0, 0, 0)
+        // binding.readerMenu.setPadding(0, 5, 0, 5)
         window.defaultBar()
     }
 

--- a/app/src/main/res/layout/reader_activity.xml
+++ b/app/src/main/res/layout/reader_activity.xml
@@ -54,7 +54,7 @@
             android:layout_height="wrap_content"
             android:animateLayoutChanges="true"
             android:background="?attr/colorPrimary"
-            app:elevation="0dp" >
+            app:elevation="0dp">
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
@@ -68,6 +68,7 @@
                 android:layout_height="match_parent"
                 android:orientation="vertical"
                 android:visibility="gone"
+                app:elevation="0dp"
                 tools:visibility="visible">
 
                 <LinearLayout
@@ -157,7 +158,8 @@
             android:background="?attr/colorPrimary"
             android:descendantFocusability="blocksDescendants"
             android:gravity="center"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:translationY="0dp">
 
             <ImageButton
                 android:id="@+id/left_chapter"
@@ -185,9 +187,9 @@
                 android:id="@+id/page_seekbar"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_weight="1"
                 android:maxHeight="?attr/actionBarSize"
-                android:minHeight="?attr/actionBarSize"
-                android:layout_weight="1" />
+                android:minHeight="?attr/actionBarSize" />
 
             <TextView
                 android:id="@+id/right_page_text"

--- a/app/src/main/res/layout/reader_activity.xml
+++ b/app/src/main/res/layout/reader_activity.xml
@@ -53,7 +53,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:animateLayoutChanges="true"
-            android:background="?attr/colorPrimary" >
+            android:background="?attr/colorPrimary"
+            app:elevation="0dp" >
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"

--- a/app/src/main/res/layout/reader_activity.xml
+++ b/app/src/main/res/layout/reader_activity.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center">
+    android:gravity="center"
+    >
 
     <FrameLayout
         android:id="@+id/reader_container"
@@ -58,10 +59,82 @@
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
+                android:paddingBottom="5dp"
                 android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize" />
+                android:layout_height="wrap_content" />
+        </com.google.android.material.appbar.AppBarLayout>
 
+        <LinearLayout
+            android:id="@+id/reader_menu_bottom"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:background="?attr/colorPrimary"
+            android:descendantFocusability="blocksDescendants"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:animateLayoutChanges="true"
+            >
+            <LinearLayout
+                android:id="@+id/reader_menu_bottom_seek"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:descendantFocusability="blocksDescendants"
+                android:gravity="center"
+                android:orientation="horizontal"
+                android:translationY="0dp"
+                >
 
+                <ImageButton
+                    android:id="@+id/left_chapter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?selectableItemBackgroundBorderless"
+                    android:contentDescription="@string/action_previous_chapter"
+                    android:padding="@dimen/material_layout_keylines_screen_edge_margin"
+                    app:srcCompat="@drawable/ic_skip_previous_24dp"
+                    app:tint="?attr/colorOnPrimary" />
+
+                <TextView
+                    android:id="@+id/left_page_text"
+                    android:layout_width="32dp"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:textSize="15sp"
+                    tools:text="1" />
+
+                <!--
+                    Wonky way of setting height due to issues with horizontally centering the thumb in Android 5.
+                    See https://stackoverflow.com/questions/15701767/android-thumb-is-not-centered-in-seekbar
+                -->
+                <eu.kanade.tachiyomi.ui.reader.ReaderSeekBar
+                    android:id="@+id/page_seekbar"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:maxHeight="?attr/actionBarSize"
+                    android:minHeight="?attr/actionBarSize" />
+
+                <TextView
+                    android:id="@+id/right_page_text"
+                    android:layout_width="32dp"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:textSize="15sp"
+                    tools:text="15" />
+
+                <ImageButton
+                    android:id="@+id/right_chapter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?selectableItemBackgroundBorderless"
+                    android:contentDescription="@string/action_next_chapter"
+                    android:padding="@dimen/material_layout_keylines_screen_edge_margin"
+                    app:srcCompat="@drawable/ic_skip_next_24dp"
+                    app:tint="?attr/colorOnPrimary" />
+
+            </LinearLayout>
             <LinearLayout
                 android:id="@+id/eh_utils"
                 android:layout_width="match_parent"
@@ -104,7 +177,7 @@
 
                 <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
+                    android:layout_height="0dp"
                     android:layout_weight="1"
                     android:orientation="horizontal">
 
@@ -140,75 +213,13 @@
                 </LinearLayout>
 
             </LinearLayout>
-
             <ImageButton
                 android:id="@+id/expand_eh_button"
                 style="?android:attr/borderlessButtonStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:padding="0dp"
-                app:srcCompat="@drawable/ic_keyboard_arrow_down_white_32dp" />
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <LinearLayout
-            android:id="@+id/reader_menu_bottom"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:layout_gravity="bottom"
-            android:background="?attr/colorPrimary"
-            android:descendantFocusability="blocksDescendants"
-            android:gravity="center"
-            android:orientation="horizontal"
-            android:translationY="0dp">
-
-            <ImageButton
-                android:id="@+id/left_chapter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="?selectableItemBackgroundBorderless"
-                android:contentDescription="@string/action_previous_chapter"
-                android:padding="@dimen/material_layout_keylines_screen_edge_margin"
-                app:srcCompat="@drawable/ic_skip_previous_24dp"
-                app:tint="?attr/colorOnPrimary" />
-
-            <TextView
-                android:id="@+id/left_page_text"
-                android:layout_width="32dp"
-                android:layout_height="match_parent"
-                android:gravity="center"
-                android:textSize="15sp"
-                tools:text="1" />
-
-            <!--
-                Wonky way of setting height due to issues with horizontally centering the thumb in Android 5.
-                See https://stackoverflow.com/questions/15701767/android-thumb-is-not-centered-in-seekbar
-            -->
-            <eu.kanade.tachiyomi.ui.reader.ReaderSeekBar
-                android:id="@+id/page_seekbar"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:maxHeight="?attr/actionBarSize"
-                android:minHeight="?attr/actionBarSize" />
-
-            <TextView
-                android:id="@+id/right_page_text"
-                android:layout_width="32dp"
-                android:layout_height="match_parent"
-                android:gravity="center"
-                android:textSize="15sp"
-                tools:text="15" />
-
-            <ImageButton
-                android:id="@+id/right_chapter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="?selectableItemBackgroundBorderless"
-                android:contentDescription="@string/action_next_chapter"
-                android:padding="@dimen/material_layout_keylines_screen_edge_margin"
-                app:srcCompat="@drawable/ic_skip_next_24dp"
-                app:tint="?attr/colorOnPrimary" />
-
+                app:srcCompat="@drawable/ic_keyboard_arrow_up_white_32dp" />
         </LinearLayout>
 
     </FrameLayout>


### PR DESCRIPTION
fixed the system gestures triggering seekbar by moving the ehutils and ehutils expander to the bottom.
this has also has the benefit of being easier to reach ehutils/autoscroll during "one handed use", so it would make sense to move the ehutils there.

also added smol padding to the MaterialToolbar so in Chapter XX the p is not cut off (don't have a screen for that sorry)
please review this, i tested it and it all worked fine, but i might've done something stupid.
collapsed:
![image](https://user-images.githubusercontent.com/21956756/166161485-32ca6baa-d158-46db-a117-51b8dae52f2d.png)
  
expanded:
![image](https://user-images.githubusercontent.com/21956756/166161495-f36a5ef2-65e5-48f7-99dd-a85e4912b78b.png)
  
i even reimplemented animations and the arrow orientation so it all makes sense