### PR TITLE
add ic_add_24p drawable (plus icon) to edit categories screen

### DIFF
--- a/app/src/main/res/layout/categories_controller.xml
+++ b/app/src/main/res/layout/categories_controller.xml
@@ -17,7 +17,7 @@
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"
         app:layout_anchor="@id/recycler"
-        style="@style/Theme.Widget.FAB"/>
+        style="@style/Theme.Widget.FAB"
         app:srcCompat="@drawable/ic_add_24dp" />
 
     <eu.kanade.tachiyomi.widget.EmptyView

--- a/app/src/main/res/layout/categories_item.xml
+++ b/app/src/main/res/layout/categories_item.xml
@@ -34,6 +34,6 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:textAppearance="@style/TextAppearance.Regular.SubHeading"
-        tools:text="Title" />
+        tools:text="title" />
 
 </LinearLayout>


### PR DESCRIPTION
the edit categories screen didn't have any icon in the fab. 
before                           |  after
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/21956756/166755384-986f2abc-087d-48d9-b612-ade17b38e284.png) | ![image](https://user-images.githubusercontent.com/21956756/166755924-04a37dd0-5db9-4309-b460-21d214a83118.png)
